### PR TITLE
feat: fetch dividend data via puppeteer

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "lodash": "^4.17.21",
     "mongodb": "^4.10.0",
     "ramda": "^0.28.0",
-    "redis": "^4.3.1"
+    "redis": "^4.3.1",
+    "puppeteer": "^22.0.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",


### PR DESCRIPTION
## Summary
- use Puppeteer to load dividend pages so that site JavaScript executes before scraping
- add Puppeteer dependency

## Testing
- `npm install puppeteer --package-lock-only` *(fails: 403 Forbidden)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d424a5c7c832d86f6804d1297376f